### PR TITLE
CXP-1297: Invalid converter instantiation

### DIFF
--- a/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
@@ -50,10 +50,6 @@ public abstract class Configure {
 				converter = (Converter) Class.forName(className).newInstance();
 			}
 
-			if (converter instanceof Configurable) {
-				((Configurable) converter).configure(props);
-			}
-
 			// grab any properties intended for the converter
 			Map<String, Object> subKeys = subKeys(classNameProp, props);
 


### PR DESCRIPTION
kafka-connect-s3 makes an extra call to `converter.configure(configs)` while Kafka Connect itself only calls `converter.configure(configs, isKey)`.

In case of `JsonConverter` this extra call causes the failure:
* Normally Kafka Connect calls `converter.configure(configs, isKey)` which adds  `converter.type` to the configuration and passes it to `converter.configure(configs)`.
* kafka-connect-s3 calls `converter.configure(configs)` first and for `JsonConverter` it fails since `converter.type` is not there yet.