### PR TITLE
CXP-1589: Optimize DelimitedRecordReader

### DIFF
--- a/common/src/test/java/com/spredfast/kafka/connect/s3/DelimitedRecordReaderTest.java
+++ b/common/src/test/java/com/spredfast/kafka/connect/s3/DelimitedRecordReaderTest.java
@@ -1,0 +1,75 @@
+package com.spredfast.kafka.connect.s3;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Test;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+public class DelimitedRecordReaderTest {
+	@Test(expected = RuntimeException.class)
+	public void testNoDelimiterAtTheEnd() throws IOException {
+		DelimitedRecordReader r = new DelimitedRecordReader(
+			"\n\n".getBytes(),
+			Optional.of("\t\t".getBytes()),
+			10
+		);
+
+		BufferedInputStream in = inputStreamFor("key1\t\tvalue1\n\nkey2\t\tvalue2");
+		ConsumerRecord<byte[], byte[]> record = r.read("t1", 0, 0, in);
+		assertArrayEquals("key1".getBytes(), record.key());
+		assertArrayEquals("value1".getBytes(), record.value());
+
+		r.read("t1", 0, 0, in);
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testSmallBuffer() throws IOException {
+		DelimitedRecordReader r = new DelimitedRecordReader(
+			"\n\n".getBytes(),
+			Optional.of("\t\t".getBytes()),
+			3
+		);
+
+		BufferedInputStream in = inputStreamFor("key1\t\tvalue1\n\nkey2\t\tvalue2");
+		r.read("t1", 0, 0, in);
+	}
+
+	@Test
+	public void testHappyPath() throws IOException {
+		DelimitedRecordReader r = new DelimitedRecordReader(
+			"\n\n".getBytes(),
+			Optional.of("\t\t".getBytes()),
+			10
+		);
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 1; i <= 10; i++) {
+			sb.append("key");
+			sb.append(i);
+			sb.append("\t\t");
+			sb.append("value");
+			sb.append(i);
+			sb.append("\n\n");
+		}
+
+		BufferedInputStream in = inputStreamFor(sb.toString());
+
+		for (int i = 1; i <= 10; i++) {
+			ConsumerRecord<byte[], byte[]> record = r.read("t1", 0, 0, in);
+			assertArrayEquals(("key"+i).getBytes(), record.key());
+			assertArrayEquals(("value"+i).getBytes(), record.value());
+		}
+
+		assertNull(r.read("t1", 0, 0, in));
+	}
+
+	private BufferedInputStream inputStreamFor(String data) {
+		return new BufferedInputStream(new ByteArrayInputStream(data.getBytes()));
+	}
+}


### PR DESCRIPTION
With this patch the bottleneck now is the method that searches for delimiters in the buffer:
<img width="1424" alt="выява" src="https://user-images.githubusercontent.com/1901945/142274605-842be9c5-1c09-4b1d-ba5c-5842f7e75bc8.png">

The emit rate has increased approx by a factor of 2. 
Before:
![выява](https://user-images.githubusercontent.com/1901945/142452996-b302eb90-58d0-4197-a196-aeeb1d3cff4d.png)
After:
<img width="1612" alt="выява" src="https://user-images.githubusercontent.com/1901945/142444002-a3509756-4865-4d8a-bd12-842582974ed5.png">