### PR TITLE
CXP-2025: Do not use task configuration for logging

### DIFF
--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
@@ -131,7 +131,7 @@ public class S3SourceTask extends SourceTask {
 				.orElse(null)
 		);
 
-		log.debug("{} reading from S3 with offsets {}", name(), offsets);
+		log.debug("Reading from S3 with offsets {}", offsets);
 
 		reader = new S3FilesReader(config, client, offsets, format::newReader).readAll();
 	}
@@ -194,7 +194,7 @@ public class S3SourceTask extends SourceTask {
 				value.schema(), value.value()));
 		}
 
-		log.debug("{} returning {} records.", name(), results.size());
+		log.debug("Returning {} records", results.size());
 		return results;
 	}
 
@@ -202,7 +202,7 @@ public class S3SourceTask extends SourceTask {
 		// store the larger offset. we don't read out of order (could probably get away with always writing what we are handed)
 		S3Offset current = offsets.getOrDefault(file, offset);
 		if (current.compareTo(offset) < 0) {
-			log.debug("{} updated offset for {} to {}", name(), file, offset);
+			log.debug("Updated offset for {} to {}", file, offset);
 			offsets.put(file, offset);
 		} else {
 			offsets.put(file, current);
@@ -210,17 +210,13 @@ public class S3SourceTask extends SourceTask {
 	}
 
 	@Override
-	public void commit() throws InterruptedException {
-		log.debug("{} Commit offsets {}", name(), offsets);
+	public void commit() {
+		log.debug("Committing offsets {}", offsets);
 	}
 
 	@Override
-	public void commitRecord(SourceRecord record) throws InterruptedException {
-		log.debug("{} Commit record w/ offset {}", name(), record.sourceOffset());
-	}
-
-	private String name() {
-		return configGet("name").orElse("???");
+	public void commitRecord(SourceRecord record) {
+		log.debug("Committing record w/ offset {}", record.sourceOffset());
 	}
 
 	private String remapTopic(String originalTopic) {


### PR DESCRIPTION
All messages for the last 5 days have the same stacktrace:
```shell
# export messages from Graylog
$ csvjson All-Messages-search-result.csv > All-Messages-search-result.json

$ jq length < All-Messages-search-result.json
9178

$ jq -r '.[].message' < All-Messages-search-result.json | sort | uniq
{"exception":{"stacktrace":"java.lang.NullPointerException\n\tat com.spredfast.kafka.connect.s3.source.S3SourceTask.configGet(S3SourceTask.java:140)\n\tat com.spredfast.kafka.connect.s3.source.S3SourceTask.name(S3SourceTask.java:223)\n\tat com.spredfast.kafka.connect.s3.source.S3SourceTask.commit(S3SourceTask.java:214)\n\tat org.apache.kafka.connect.runtime.WorkerSourceTask.commitSourceTask(WorkerSourceTask.java:596)\n\tat org.apache.kafka.connect.runtime.WorkerSourceTask.commitOffsets(WorkerSourceTask.java:540)\n\tat org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.commit(SourceTaskOffsetCommitter.java:110)\n\tat org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.lambda$schedule$0(SourceTaskOffsetCommitter.java:84)\n\tat java.base\/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\n\tat java.base\/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)\n\tat java.base\/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoo
```
Formatted, the above stracktrace is:
```
java.lang.NullPointerException
	at com.spredfast.kafka.connect.s3.source.S3SourceTask.configGet(S3SourceTask.java:140)
	at com.spredfast.kafka.connect.s3.source.S3SourceTask.name(S3SourceTask.java:223)
	at com.spredfast.kafka.connect.s3.source.S3SourceTask.commit(S3SourceTask.java:214)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.commitSourceTask(WorkerSourceTask.java:596)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.commitOffsets(WorkerSourceTask.java:540)
	at org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.commit(SourceTaskOffsetCommitter.java:110)
	at org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.lambda$schedule$0(SourceTaskOffsetCommitter.java:84)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

There are `NULL`s in the `configs` topics:

```shell
$ jq -r 'select(.payload==null) | .key' cxp-connect-configs-k8s-usw2-prod.json | sort | uniq
connector-cxp-core-streaming-mtpremiumus01-tmp-events-s3-source
connector-cxp-core-streaming-mtpremiumus03-tmp-events-s3-source
connector-cxp-core-streaming-mtpremiumus05-tmp-events-s3-source
...
target-state-ondemandus16-us-west-2-5c17fc8836f40c2d703dfb98-s3-source
target-state-premiumus02-us-west-2-5b01ac0a36f40c5ed1384dfd-s3-source
target-state-premiumus03-us-west-2-5b00cee87d10c93322698cc6-s3-source
```

These `NULL`s seem to be [valid](https://github.com/apache/kafka/blob/3fc54043bf1cf197965e67d75e7f37250f406966/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java#L355-L359):
```java
public void removeConnectorConfig(String connector) {
    log.debug("Removing connector configuration for connector '{}'", connector);
    try {
        configLog.send(CONNECTOR_KEY(connector), null);
        configLog.send(TARGET_STATE_KEY(connector), null);
```
But there isn't a single `task-` key with a `NULL` value which would represent an invalid configuration.

It looks like there are circumstances (maybe a race condition?) when the task is requested to commit its offsets but doesn't have a configuration (yet?). In any event, since this is the only stack trace where the exception occurs, we don't need to log the name of the connector explicitly, it's available as part of the logging context. If it wasn't, we wouldn't know which of the connector's task the message belongs to anyways.

I looked at other connectors like Debezium and the ones from the Apache Kafka repository, and none of them use task configuration for logging.