### PR TITLE
CXP-2029: Changing S3 storage layout for historical data

### DIFF
--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
@@ -62,12 +62,10 @@ public class S3Writer {
 		this.tm = tm;
 	}
 
-	public long putChunk(String localDataFile, String localIndexFile, TopicPartition tp) throws IOException {
+	public void putChunk(String localDataFile, String localIndexFile, TopicPartition tp) throws IOException {
 		// Put data file then index, then finally update/create the last_index_file marker
 		String dataFileKey = this.getChunkFileKey(localDataFile);
 		String idxFileKey = this.getChunkFileKey(localIndexFile);
-		// Read offset first since we'll delete the file after upload
-		long nextOffset = getNextOffsetFromIndexFileContents(new FileReader(localIndexFile));
 
 		try {
 			Upload upload = tm.upload(this.bucket, dataFileKey, new File(localDataFile));
@@ -79,9 +77,6 @@ public class S3Writer {
 		}
 
 		this.updateCursorFile(idxFileKey, tp);
-
-		// Sanity check - return what the new nextOffset will be based on the index we just uploaded
-		return nextOffset;
 	}
 
 	public long fetchOffset(TopicPartition tp) throws IOException {

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
@@ -129,11 +129,11 @@ public class S3Writer {
 		df.setTimeZone(UTC);
 		final String date = df.format(new Date());
 
-		return String.format("%s%s/%s-%05d-%012d.%s", keyPrefix, date, tp.topic(), tp.partition(), firstRecordOffset, extension);
+		return String.format("%s%s/%s/%05d-%012d.%s", keyPrefix, tp.topic(), date, tp.partition(), firstRecordOffset, extension);
 	}
 
 	private String getTopicPartitionLastIndexFileKey(TopicPartition tp) {
-		return String.format("%slast_chunk_index.%s-%05d.txt", keyPrefix, tp.topic(), tp.partition());
+		return String.format("%s%s/last_chunk_index.%05d.txt", keyPrefix, tp.topic(), tp.partition());
 	}
 
 	private void updateCursorFile(String lastIndexFileKey, TopicPartition tp) throws IOException {

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
@@ -38,6 +39,7 @@ import com.spredfast.kafka.connect.s3.sink.S3Writer;
  * how well I can mock S3 API beyond a certain point.
  */
 public class S3WriterTest {
+	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
 	private String testBucket = "kafka-connect-s3-unit-test";
 	private String tmpDirPrefix = "S3WriterTest";
@@ -121,6 +123,7 @@ public class S3WriterTest {
 
 	private String getKeyForFilename(String prefix, String name) {
 		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+		df.setTimeZone(UTC);
 		return String.format("%s/%s/%s", prefix, df.format(new Date()), name);
 	}
 

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -43,27 +43,25 @@ public class S3WriterTest {
 
 	private String testBucket = "kafka-connect-s3-unit-test";
 	private String tmpDirPrefix = "S3WriterTest";
-	private String tmpDir;
+	private File tmpDir;
 
 	public S3WriterTest() {
 
 		String tempDir = System.getProperty("java.io.tmpdir");
-		this.tmpDir = new File(tempDir, tmpDirPrefix).toString();
+		this.tmpDir = new File(tempDir, tmpDirPrefix);
 
 		System.out.println("Temp dir for writer test is: " + tmpDir);
 	}
 
 	@Before
 	public void setUp() throws Exception {
-		File f = new File(tmpDir);
-
-		if (!f.exists()) {
-			f.mkdir();
+		if (!tmpDir.exists()) {
+			tmpDir.mkdir();
 		}
 	}
 
 	private BlockGZIPFileWriter createDummmyFiles(long offset, int numRecords) throws Exception {
-		BlockGZIPFileWriter writer = new BlockGZIPFileWriter("bar-00000", tmpDir, offset);
+		BlockGZIPFileWriter writer = new BlockGZIPFileWriter(tmpDir, offset);
 		for (int i = 0; i < numRecords; i++) {
 			writer.write(Arrays.asList(String.format("Record %d", i).getBytes()), 1);
 		}
@@ -142,7 +140,7 @@ public class S3WriterTest {
 		when(tmMock.upload(eq(testBucket), eq(getKeyForFilename("pfx", "bar-00000-000000000000.index.json")), isA(File.class)))
 			.thenReturn(mockUpload);
 
-		s3Writer.putChunk(fileWriter.getDataFilePath(), fileWriter.getIndexFilePath(), tp);
+		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), tp, fileWriter.getFirstRecordOffset());
 
 		verifyTMUpload(tmMock, new ExpectedRequestParams[]{
 			new ExpectedRequestParams(getKeyForFilename("pfx", "bar-00000-000000000000.gz"), testBucket),

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -2,7 +2,6 @@ package com.spredfast.kafka.connect.s3;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -343,8 +342,8 @@ public class S3FilesReaderTest {
 
 	private void givenASingleDayWithManyPartitions(Path dir, boolean includeKeys) throws IOException {
 		new File(dir.toFile(), "prefix/2016-01-01").mkdirs();
-		try (BlockGZIPFileWriter p0 = new BlockGZIPFileWriter("topic-00000", dir.toString() + "/prefix/2016-01-01", 0, 512);
-			 BlockGZIPFileWriter p1 = new BlockGZIPFileWriter("topic-00001", dir.toString() + "/prefix/2016-01-01", 0, 512);
+		try (BlockGZIPFileWriter p0 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2016-01-01", 0, 512);
+             BlockGZIPFileWriter p1 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2016-01-01", 0, 512);
 		) {
 			write(p0, "key0-0".getBytes(), "value0-0".getBytes(), includeKeys);
 			write(p1, "key1-0".getBytes(), "value1-0".getBytes(), includeKeys);
@@ -361,10 +360,10 @@ public class S3FilesReaderTest {
 		new File(dir.toFile(), "prefix/2015-12-31").mkdirs();
 		new File(dir.toFile(), "prefix/2016-01-01").mkdirs();
 		new File(dir.toFile(), "prefix/2016-01-02").mkdirs();
-		try (BlockGZIPFileWriter writer0 = new BlockGZIPFileWriter("topic-00003", dir.toString() + "/prefix/2015-12-31", 1, 512);
-			 BlockGZIPFileWriter writer1 = new BlockGZIPFileWriter("topic-00000", dir.toString() + "/prefix/2016-01-01", 0, 512);
-			 BlockGZIPFileWriter writer2 = new BlockGZIPFileWriter("topic-00001", dir.toString() + "/prefix/2016-01-02", 0, 512);
-			 BlockGZIPFileWriter preWriter1 = new BlockGZIPFileWriter("topic-00003", dir.toString() + "/prefix/2015-12-30", 0, 512);
+		try (BlockGZIPFileWriter writer0 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2015-12-31", 1, 512);
+             BlockGZIPFileWriter writer1 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2016-01-01", 0, 512);
+             BlockGZIPFileWriter writer2 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2016-01-02", 0, 512);
+             BlockGZIPFileWriter preWriter1 = new BlockGZIPFileWriter(dir.toString() + "/prefix/2015-12-30", 0, 512);
 		) {
 			write(preWriter1, "willbe".getBytes(), "skipped0".getBytes(), includeKeys);
 


### PR DESCRIPTION
The problem with the current design is that different parts of the resulting S3 object keys are built by different components: the filename which contains the topic name and partition is built by `BlockGZIPFileWriter` but the path containing the date is built by `S3Writer`.

**Key changes**:
1. Remove the logic of generating filenames from `BlockGZIPFileWriter`. Instead, it should just produce temporary files in the destination directory.
2. Move the logic of generating filenames to `S3Writer`.
3. Move all the logic of generating the object key to a single method `getObjectKey()`.