### PR TITLE
CXP-2389: Refactor writer logic of building S3 object keys

### DIFF
--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3Writer.java
@@ -62,12 +62,10 @@ public class S3Writer {
 		this.tm = tm;
 	}
 
-	public long putChunk(String localDataFile, String localIndexFile, TopicPartition tp) throws IOException {
+	public void putChunk(String localDataFile, String localIndexFile, TopicPartition tp) throws IOException {
 		// Put data file then index, then finally update/create the last_index_file marker
 		String dataFileKey = this.getChunkFileKey(localDataFile);
 		String idxFileKey = this.getChunkFileKey(localIndexFile);
-		// Read offset first since we'll delete the file after upload
-		long nextOffset = getNextOffsetFromIndexFileContents(new FileReader(localIndexFile));
 
 		try {
 			Upload upload = tm.upload(this.bucket, dataFileKey, new File(localDataFile));
@@ -79,9 +77,6 @@ public class S3Writer {
 		}
 
 		this.updateCursorFile(idxFileKey, tp);
-
-		// Sanity check - return what the new nextOffset will be based on the index we just uploaded
-		return nextOffset;
 	}
 
 	public long fetchOffset(TopicPartition tp) throws IOException {

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
@@ -38,6 +39,7 @@ import com.spredfast.kafka.connect.s3.sink.S3Writer;
  * how well I can mock S3 API beyond a certain point.
  */
 public class S3WriterTest {
+	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
 	private String testBucket = "kafka-connect-s3-unit-test";
 	private String tmpDirPrefix = "S3WriterTest";
@@ -121,6 +123,7 @@ public class S3WriterTest {
 
 	private String getKeyForFilename(String prefix, String name) {
 		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+		df.setTimeZone(UTC);
 		return String.format("%s/%s/%s", prefix, df.format(new Date()), name);
 	}
 

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -43,27 +43,25 @@ public class S3WriterTest {
 
 	private String testBucket = "kafka-connect-s3-unit-test";
 	private String tmpDirPrefix = "S3WriterTest";
-	private String tmpDir;
+	private File tmpDir;
 
 	public S3WriterTest() {
 
 		String tempDir = System.getProperty("java.io.tmpdir");
-		this.tmpDir = new File(tempDir, tmpDirPrefix).toString();
+		this.tmpDir = new File(tempDir, tmpDirPrefix);
 
 		System.out.println("Temp dir for writer test is: " + tmpDir);
 	}
 
 	@Before
 	public void setUp() throws Exception {
-		File f = new File(tmpDir);
-
-		if (!f.exists()) {
-			f.mkdir();
+		if (!tmpDir.exists()) {
+			tmpDir.mkdir();
 		}
 	}
 
 	private BlockGZIPFileWriter createDummmyFiles(long offset, int numRecords) throws Exception {
-		BlockGZIPFileWriter writer = new BlockGZIPFileWriter("bar-00000", tmpDir, offset);
+		BlockGZIPFileWriter writer = new BlockGZIPFileWriter(tmpDir, offset);
 		for (int i = 0; i < numRecords; i++) {
 			writer.write(Arrays.asList(String.format("Record %d", i).getBytes()), 1);
 		}
@@ -142,7 +140,7 @@ public class S3WriterTest {
 		when(tmMock.upload(eq(testBucket), eq(getKeyForFilename("pfx", "bar-00000-000000000000.index.json")), isA(File.class)))
 			.thenReturn(mockUpload);
 
-		s3Writer.putChunk(fileWriter.getDataFilePath(), fileWriter.getIndexFilePath(), tp);
+		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), tp, fileWriter.getFirstRecordOffset());
 
 		verifyTMUpload(tmMock, new ExpectedRequestParams[]{
 			new ExpectedRequestParams(getKeyForFilename("pfx", "bar-00000-000000000000.gz"), testBucket),

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3FilesReader.java
@@ -107,7 +107,7 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 	private static final Pattern DATA_SUFFIX = Pattern.compile("\\.gz$");
 
 	private int partition(String key) {
-		final Matcher matcher = config.keyPattern.matcher(key);
+		final Matcher matcher = S3FilesReader.DEFAULT_PATTERN.matcher(key);
 		if (!matcher.find()) {
 			throw new IllegalArgumentException("Not a valid chunk filename! " + key);
 		}
@@ -115,7 +115,7 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 	}
 
 	private String topic(String key) {
-		final Matcher matcher = config.keyPattern.matcher(key);
+		final Matcher matcher = S3FilesReader.DEFAULT_PATTERN.matcher(key);
 		if (!matcher.find()) {
 			throw new IllegalArgumentException("Not a valid chunk filename! " + key);
 		}
@@ -344,7 +344,7 @@ public class S3FilesReader implements Iterable<S3SourceRecord> {
 	}
 
 	private <T> T parseKey(String key, KeyConsumer<T> consumer) throws IOException {
-		final Matcher matcher = config.keyPattern.matcher(key);
+		final Matcher matcher = S3FilesReader.DEFAULT_PATTERN.matcher(key);
 		if (!matcher.find()) {
 			throw new IllegalArgumentException("Not a valid chunk filename! " + key);
 		}

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceConfig.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceConfig.java
@@ -8,7 +8,6 @@ public class S3SourceConfig {
 	public String keyPrefix = "";
 	public int pageSize = 500;
 	public String startMarker = null; // for partial replay
-	public Pattern keyPattern = S3FilesReader.DEFAULT_PATTERN;
 	public S3FilesReader.InputFilter inputFilter = S3FilesReader.InputFilter.GUNZIP;
 	public S3FilesReader.PartitionFilter partitionFilter = S3FilesReader.PartitionFilter.MATCH_ALL;
 	public List<String> messageKeyExcludeList;
@@ -17,12 +16,11 @@ public class S3SourceConfig {
 		this.bucket = bucket;
 	}
 
-	public S3SourceConfig(String bucket, String keyPrefix, int pageSize, String startMarker, Pattern keyPattern, S3FilesReader.InputFilter inputFilter, S3FilesReader.PartitionFilter partitionFilter, List<String> messageKeyExcludeList) {
+	public S3SourceConfig(String bucket, String keyPrefix, int pageSize, String startMarker, S3FilesReader.InputFilter inputFilter, S3FilesReader.PartitionFilter partitionFilter, List<String> messageKeyExcludeList) {
 		this.bucket = bucket;
 		this.keyPrefix = keyPrefix;
 		this.pageSize = pageSize;
 		this.startMarker = startMarker;
-		this.keyPattern = keyPattern;
 		if (inputFilter != null) {
 			this.inputFilter = inputFilter;
 		}

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
@@ -122,7 +122,6 @@ public class S3SourceTask extends SourceTask {
 			bucket, prefix,
 			configGet("s3.page.size").map(Integer::parseInt).orElse(100),
 			configGet("s3.start.marker").orElse(null),
-			S3FilesReader.DEFAULT_PATTERN,
 			S3FilesReader.InputFilter.GUNZIP,
 			S3FilesReader.PartitionFilter.from((topic, partition) ->
 				(topics.isEmpty() || topics.contains(topic))

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -147,7 +147,7 @@ public class S3FilesReaderTest {
 		int partInt = Integer.valueOf(partition, 10);
 		offsets.put(S3Partition.from("bucket", "prefix", "topic", partInt),
 			S3Offset.from(marker, nextOffset - 1 /* an S3 offset is the last record processed, so go back 1 to consume next */));
-		return new S3FilesReader(new S3SourceConfig("bucket", "prefix", 1, null, S3FilesReader.DEFAULT_PATTERN, S3FilesReader.InputFilter.GUNZIP,
+		return new S3FilesReader(new S3SourceConfig("bucket", "prefix", 1, null, S3FilesReader.InputFilter.GUNZIP,
 			p -> partInt == p, null), client, offsets, () -> new BytesRecordReader(true));
 	}
 
@@ -217,13 +217,13 @@ public class S3FilesReaderTest {
 	}
 
 	private List<String> whenTheRecordsAreRead(AmazonS3 client, List<String> messageKeyExcludeList) {
-		S3SourceConfig config = new S3SourceConfig("bucket", "prefix", 3, "prefix/2016-01-01", S3FilesReader.DEFAULT_PATTERN, S3FilesReader.InputFilter.GUNZIP, null, messageKeyExcludeList);
+		S3SourceConfig config = new S3SourceConfig("bucket", "prefix", 3, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, messageKeyExcludeList);
 		S3FilesReader reader = new S3FilesReader(config, client, null,() -> new BytesRecordReader(true));
 		return whenTheRecordsAreRead(reader);
 	}
 
 	private List<String> whenTheRecordsAreRead(AmazonS3 client, boolean fileIncludesKeys, int pageSize) {
-		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, "prefix/2016-01-01", S3FilesReader.DEFAULT_PATTERN, S3FilesReader.InputFilter.GUNZIP, null, null), client, null,() -> new BytesRecordReader(fileIncludesKeys));
+		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, null), client, null,() -> new BytesRecordReader(fileIncludesKeys));
 		return whenTheRecordsAreRead(reader);
 	}
 


### PR DESCRIPTION
Originally prototyped in https://github.com/sugarcrm/kafka-connect-s3/pull/16.

The problem with the current design is that different parts of the resulting S3 object keys are built by different components: the filename which contains the topic name and partition is built by `BlockGZIPFileWriter` but the path containing the date is built by `S3Writer`.

**Key changes**:
1. Remove the logic of generating filenames from `BlockGZIPFileWriter`. Instead, it should just produce temporary files in the destination directory.
2. Move the logic of generating filenames to `S3Writer`.
3. Move all the logic of generating the object key to a single method `getObjectKey()`.
4. Rework the `S3FilesReaderTest` methods that produce test data. Instead of relying on `BlockGZIPFileWriter` building the expected object keys (which it no longer does), the test mimics the behavior of the `S3Writer` and lays out the files as the reader expects.