### PR TITLE
CXP-2366: Introduce layout configuration

### DIFF
--- a/common/src/main/java/com/spredfast/kafka/connect/s3/BlockMetadata.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/BlockMetadata.java
@@ -1,0 +1,21 @@
+package com.spredfast.kafka.connect.s3;
+
+import org.apache.kafka.common.TopicPartition;
+
+final public class BlockMetadata {
+    final private TopicPartition topicPartition;
+    final private long startOffset;
+
+    public BlockMetadata(TopicPartition topicPartition, long startOffset) {
+        this.topicPartition = topicPartition;
+        this.startOffset = startOffset;
+    }
+
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+
+    public long getStartOffset() {
+        return startOffset;
+    }
+}

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -129,6 +130,18 @@ public abstract class Configure {
 		} catch (Exception e) {
 			throw new ConnectException("Failed to create format: " + props.get("format"), e);
 		}
+	}
+
+	public static Layout createLayout(Map<String, String> props) {
+		final Supplier<String> dateSupplier = new CurrentUtcDateSupplier();
+
+		String type = props.getOrDefault("layout", "grouped_by_date");
+
+		if (type.equals("grouped_by_date")) {
+			return new GroupedByDateLayout(dateSupplier);
+		}
+
+		throw new IllegalArgumentException("Unknown layout type: " + type);
 	}
 
 	public static Map<String, String> parseTags(String tagString) {

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/CurrentUtcDateSupplier.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/CurrentUtcDateSupplier.java
@@ -1,0 +1,26 @@
+package com.spredfast.kafka.connect.s3;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.function.Supplier;
+
+/**
+ * We store block objects with a date prefix just to make finding them and navigating around the bucket
+ * a bit easier. The meaning of the date is "when this block was uploaded".
+ */
+public class CurrentUtcDateSupplier implements Supplier<String> {
+    private final DateFormat dateFormat;
+
+    public CurrentUtcDateSupplier() {
+        final TimeZone UTC = TimeZone.getTimeZone("UTC");
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        dateFormat.setTimeZone(UTC);
+    }
+
+    @Override
+    public String get() {
+        return dateFormat.format(new Date());
+    }
+}

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/Layout.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/Layout.java
@@ -1,0 +1,21 @@
+package com.spredfast.kafka.connect.s3;
+
+import org.apache.kafka.common.TopicPartition;
+
+public interface Layout {
+
+    Builder getBuilder();
+
+    Parser getParser();
+
+    interface Builder {
+
+        String buildBlockPath(BlockMetadata blockMetadata);
+
+        String buildIndexPath(TopicPartition topicPartition);
+    }
+
+    interface Parser {
+        BlockMetadata parseBlockPath(String path) throws IllegalArgumentException;
+    }
+}

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/BlockGZIPFileWriter.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/BlockGZIPFileWriter.java
@@ -94,31 +94,31 @@ public class BlockGZIPFileWriter implements Closeable {
 	// Default each chunk is 64MB of uncompressed data
 	private long chunkThreshold;
 
-	// Offset to the first record.
+	// Start offset of the block.
 	// Set to non-zero if this file is part of a larger stream and you want
 	// record offsets in the index to reflect the global offset rather than local
-	private long firstRecordOffset;
+	private long startOffset;
 
 	public BlockGZIPFileWriter(File directory) throws IOException {
 		this(directory, 0, 67108864);
 	}
 
-	public BlockGZIPFileWriter(File directory, long firstRecordOffset) throws IOException {
-		this(directory, firstRecordOffset, 67108864);
+	public BlockGZIPFileWriter(File directory, long startOffset) throws IOException {
+		this(directory, startOffset, 67108864);
 	}
 
-	public BlockGZIPFileWriter(File directory, long firstRecordOffset, long chunkThreshold) throws IOException {
-		this(directory, firstRecordOffset, chunkThreshold, new byte[0]);
+	public BlockGZIPFileWriter(File directory, long startOffset, long chunkThreshold) throws IOException {
+		this(directory, startOffset, chunkThreshold, new byte[0]);
 	}
 
-	public BlockGZIPFileWriter(File directory, long firstRecordOffset, long chunkThreshold, byte[] header)
+	public BlockGZIPFileWriter(File directory, long startOffset, long chunkThreshold, byte[] header)
 		throws IOException {
-		this.firstRecordOffset = firstRecordOffset;
+		this.startOffset = startOffset;
 		this.chunkThreshold = chunkThreshold;
 
 		// Initialize first chunk
 		Chunk ch = new Chunk();
-		ch.firstOffset = firstRecordOffset;
+		ch.firstOffset = startOffset;
 		chunks.add(ch);
 
 		dataFile = File.createTempFile("data", null, directory);
@@ -156,8 +156,8 @@ public class BlockGZIPFileWriter implements Closeable {
 		return indexFile;
 	}
 
-	public long getFirstRecordOffset() {
-		return firstRecordOffset;
+	public long getStartOffset() {
+		return startOffset;
 	}
 
 	/**

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
@@ -222,7 +222,7 @@ public class S3SinkTask extends SinkTask {
 					writer.close();
 					closed = true;
 				}
-				s3.putChunk(writer.getDataFile(), writer.getIndexFile(), tp, writer.getFirstRecordOffset());
+				s3.putChunk(writer.getDataFile(), writer.getIndexFile(), tp, writer.getStartOffset());
 			} catch (IOException e) {
 				throw new RetriableException("Error flushing " + tp, e);
 			}

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -140,7 +140,7 @@ public class S3WriterTest {
 		when(tmMock.upload(eq(testBucket), eq(getKeyForFilename("pfx", "bar-00000-000000000000.index.json")), isA(File.class)))
 			.thenReturn(mockUpload);
 
-		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), tp, fileWriter.getFirstRecordOffset());
+		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), tp, fileWriter.getStartOffset());
 
 		verifyTMUpload(tmMock, new ExpectedRequestParams[]{
 			new ExpectedRequestParams(getKeyForFilename("pfx", "bar-00000-000000000000.gz"), testBucket),

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -14,11 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
@@ -39,7 +36,8 @@ import com.spredfast.kafka.connect.s3.sink.S3Writer;
  * how well I can mock S3 API beyond a certain point.
  */
 public class S3WriterTest {
-	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+	private static final Layout.Builder LAYOUT_BUILDER = new GroupedByDateLayout(new CurrentUtcDateSupplier())
+			.getBuilder();
 
 	private String testBucket = "kafka-connect-s3-unit-test";
 	private String tmpDirPrefix = "S3WriterTest";
@@ -119,10 +117,10 @@ public class S3WriterTest {
 		assertEquals(content, sb.toString());
 	}
 
-	private String getKeyForFilename(String prefix, String name) {
-		SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-		df.setTimeZone(UTC);
-		return String.format("%s/%s/%s", prefix, df.format(new Date()), name);
+	private String getKeyForFilename(String prefix, String topic, int partition, long startOffset, String extension) {
+		final TopicPartition topicPartition = new TopicPartition(topic, partition);
+		final BlockMetadata blockMetadata = new BlockMetadata(topicPartition, startOffset);
+		return String.format("%s/%s%s", prefix, LAYOUT_BUILDER.buildBlockPath(blockMetadata), extension);
 	}
 
 	@Test
@@ -130,26 +128,28 @@ public class S3WriterTest {
 		AmazonS3 s3Mock = mock(AmazonS3.class);
 		TransferManager tmMock = mock(TransferManager.class);
 		BlockGZIPFileWriter fileWriter = createDummmyFiles(0, 1000);
-		S3Writer s3Writer = new S3Writer(testBucket, "pfx", s3Mock, tmMock);
+		S3Writer s3Writer = new S3Writer(testBucket, "pfx", LAYOUT_BUILDER, s3Mock, tmMock);
 		TopicPartition tp = new TopicPartition("bar", 0);
 
 		Upload mockUpload = mock(Upload.class);
 
-		when(tmMock.upload(eq(testBucket), eq(getKeyForFilename("pfx", "bar-00000-000000000000.gz")), isA(File.class)))
+		String dataKey = getKeyForFilename("pfx", "bar", 0, 0, ".gz");
+		String indexKey = getKeyForFilename("pfx", "bar", 0, 0, ".index.json");
+
+		when(tmMock.upload(eq(testBucket), eq(dataKey), isA(File.class)))
 			.thenReturn(mockUpload);
-		when(tmMock.upload(eq(testBucket), eq(getKeyForFilename("pfx", "bar-00000-000000000000.index.json")), isA(File.class)))
+		when(tmMock.upload(eq(testBucket), eq(indexKey), isA(File.class)))
 			.thenReturn(mockUpload);
 
-		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), tp, fileWriter.getStartOffset());
+		s3Writer.putChunk(fileWriter.getDataFile(), fileWriter.getIndexFile(), new BlockMetadata(tp, fileWriter.getStartOffset()));
 
 		verifyTMUpload(tmMock, new ExpectedRequestParams[]{
-			new ExpectedRequestParams(getKeyForFilename("pfx", "bar-00000-000000000000.gz"), testBucket),
-			new ExpectedRequestParams(getKeyForFilename("pfx", "bar-00000-000000000000.index.json"), testBucket)
+			new ExpectedRequestParams(dataKey, testBucket),
+			new ExpectedRequestParams(indexKey, testBucket)
 		});
 
 		// Verify it also wrote the index file key
-		verifyStringPut(s3Mock, "pfx/last_chunk_index.bar-00000.txt",
-			getKeyForFilename("pfx", "bar-00000-000000000000.index.json"));
+		verifyStringPut(s3Mock, "pfx/last_chunk_index.bar-00000.txt", indexKey);
 	}
 
 	private S3Object makeMockS3Object(String key, String contents) throws Exception {
@@ -165,7 +165,7 @@ public class S3WriterTest {
 	@Test
 	public void testFetchOffsetNewTopic() throws Exception {
 		AmazonS3 s3Mock = mock(AmazonS3.class);
-		S3Writer s3Writer = new S3Writer(testBucket, "pfx", s3Mock);
+		S3Writer s3Writer = new S3Writer(testBucket, "pfx", LAYOUT_BUILDER, s3Mock);
 
 		// Non existing topic should return 0 offset
 		// Since the file won't exist. code will expect the initial fetch to 404
@@ -184,11 +184,11 @@ public class S3WriterTest {
 	@Test
 	public void testFetchOffsetExistingTopic() throws Exception {
 		AmazonS3 s3Mock = mock(AmazonS3.class);
-		S3Writer s3Writer = new S3Writer(testBucket, "pfx", s3Mock);
+		S3Writer s3Writer = new S3Writer(testBucket, "pfx", LAYOUT_BUILDER, s3Mock);
 		// Existing topic should return correct offset
 		// We expect 2 fetches, one for the cursor file
 		// and second for the index file itself
-		String indexKey = getKeyForFilename("pfx", "bar-00000-000000010042.index.json");
+		String indexKey = getKeyForFilename("pfx", "bar", 0, 10042, ".index.json");
 
 		when(s3Mock.getObject(eq(testBucket), eq("pfx/last_chunk_index.bar-00000.txt")))
 			.thenReturn(

--- a/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
+++ b/source/src/main/java/com/spredfast/kafka/connect/s3/source/S3SourceTask.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.spredfast.kafka.connect.s3.AlreadyBytesConverter;
 import com.spredfast.kafka.connect.s3.Constants;
 import com.spredfast.kafka.connect.s3.Configure;
+import com.spredfast.kafka.connect.s3.Layout;
 import com.spredfast.kafka.connect.s3.S3;
 import com.spredfast.kafka.connect.s3.S3RecordFormat;
 
@@ -117,6 +118,7 @@ public class S3SourceTask extends SourceTask {
 
 		AmazonS3 client = S3.s3client(taskConfig);
 
+		Layout layout = Configure.createLayout(taskConfig);
 
 		S3SourceConfig config = new S3SourceConfig(
 			bucket, prefix,
@@ -133,7 +135,7 @@ public class S3SourceTask extends SourceTask {
 
 		log.debug("Reading from S3 with offsets {}", offsets);
 
-		reader = new S3FilesReader(config, client, offsets, format::newReader).readAll();
+		reader = new S3FilesReader(config, client, offsets, layout.getParser(), format::newReader).readAll();
 	}
 
 	private Optional<String> configGet(String key) {

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -58,6 +58,7 @@ import com.spredfast.kafka.connect.s3.source.S3SourceRecord;
  * Covers S3 and reading raw byte records. Closer to an integration test.
  */
 public class S3FilesReaderTest {
+	private static final Layout.Parser LAYOUT_PARSER = new GroupedByDateLayout.Parser();
 
 	@Test
 	public void testReadingBytesFromS3() throws IOException, NoSuchFieldException {
@@ -149,7 +150,7 @@ public class S3FilesReaderTest {
 		offsets.put(S3Partition.from("bucket", "prefix", "topic", partInt),
 			S3Offset.from(marker, nextOffset - 1 /* an S3 offset is the last record processed, so go back 1 to consume next */));
 		return new S3FilesReader(new S3SourceConfig("bucket", "prefix", 1, null, S3FilesReader.InputFilter.GUNZIP,
-			p -> partInt == p, null), client, offsets, () -> new BytesRecordReader(true));
+			p -> partInt == p, null), client, offsets, LAYOUT_PARSER, () -> new BytesRecordReader(true));
 	}
 
 	public static class ReversedStringBytesConverter implements Converter {
@@ -219,12 +220,12 @@ public class S3FilesReaderTest {
 
 	private List<String> whenTheRecordsAreRead(AmazonS3 client, List<String> messageKeyExcludeList) {
 		S3SourceConfig config = new S3SourceConfig("bucket", "prefix", 3, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, messageKeyExcludeList);
-		S3FilesReader reader = new S3FilesReader(config, client, null,() -> new BytesRecordReader(true));
+		S3FilesReader reader = new S3FilesReader(config, client, null, LAYOUT_PARSER, () -> new BytesRecordReader(true));
 		return whenTheRecordsAreRead(reader);
 	}
 
 	private List<String> whenTheRecordsAreRead(AmazonS3 client, boolean fileIncludesKeys, int pageSize) {
-		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, null), client, null,() -> new BytesRecordReader(fileIncludesKeys));
+		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, null), client, null, LAYOUT_PARSER, () -> new BytesRecordReader(fileIncludesKeys));
 		return whenTheRecordsAreRead(reader);
 	}
 
@@ -393,7 +394,9 @@ public class S3FilesReaderTest {
 	}
 
 	private void rename(File file, Path dir, String date, int partition, long startOffset, String extension) {
-		final File dest = new File(dir.toFile(), String.format("prefix/%s/topic-%05d-%012d%s", date, partition, startOffset, extension));
+		Layout.Builder layoutBuilder = new GroupedByDateLayout.Builder(() -> date);
+		final BlockMetadata metadata = new BlockMetadata(new TopicPartition("topic", partition), startOffset);
+		final File dest = new File(dir.toFile(), "prefix/" + layoutBuilder.buildBlockPath(metadata) + extension);
 		dest.getParentFile().mkdirs();
 		assertTrue(file.renameTo(dest));
 	}

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -388,8 +388,8 @@ public class S3FilesReaderTest {
 
 	private void upload(BlockGZIPFileWriter writer, Path dir, String date, int partition) throws IOException {
 		writer.close();
-		rename(writer.getDataFile(), dir, date, partition, writer.getFirstRecordOffset(), ".gz");
-		rename(writer.getIndexFile(), dir, date, partition, writer.getFirstRecordOffset(), ".index.json");
+		rename(writer.getDataFile(), dir, date, partition, writer.getStartOffset(), ".gz");
+		rename(writer.getIndexFile(), dir, date, partition, writer.getStartOffset(), ".index.json");
 	}
 
 	private void rename(File file, Path dir, String date, int partition, long startOffset, String extension) {


### PR DESCRIPTION
This pull request introduces the `Layout` interface and its `GroupedByDateLayout` implementation. It also reworks the code and the tests to use the layout of building and parsing file paths instead of duplicating the building and parsing logic in the tests.

The next step is the introduction of the `GroupedByTopicLayout` and additional rework of the tests (drafted in https://github.com/morozov/kafka-connect-s3/compare/CXP-2366...morozov:kafka-connect-s3:CXP-2391).