### PR TITLE
CXP-2391: Introduce GroupedByTopicLayout

### DIFF
--- a/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/Configure.java
@@ -137,11 +137,14 @@ public abstract class Configure {
 
 		String type = props.getOrDefault("layout", "grouped_by_date");
 
-		if (type.equals("grouped_by_date")) {
-			return new GroupedByDateLayout(dateSupplier);
+		switch (type) {
+			case "grouped_by_date":
+				return new GroupedByDateLayout(dateSupplier);
+			case "grouped_by_topic":
+				return new GroupedByTopicLayout(dateSupplier);
+			default:
+				throw new IllegalArgumentException("Unknown layout type: " + type);
 		}
-
-		throw new IllegalArgumentException("Unknown layout type: " + type);
 	}
 
 	public static Map<String, String> parseTags(String tagString) {

--- a/common/src/main/java/com/spredfast/kafka/connect/s3/GroupedByTopicLayout.java
+++ b/common/src/main/java/com/spredfast/kafka/connect/s3/GroupedByTopicLayout.java
@@ -1,0 +1,71 @@
+package com.spredfast.kafka.connect.s3;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GroupedByTopicLayout implements Layout {
+
+    private final Supplier<String> dateSupplier;
+
+    public GroupedByTopicLayout(Supplier<String> dateSupplier) {
+        this.dateSupplier = dateSupplier;
+    }
+
+    public Layout.Builder getBuilder() {
+        return new Builder(dateSupplier);
+    }
+
+    public Layout.Parser getParser() {
+        return new Parser();
+    }
+
+    static class Builder implements Layout.Builder {
+
+        private final Supplier<String> dateSupplier;
+
+        public Builder(Supplier<String> dateSupplier) {
+            this.dateSupplier = dateSupplier;
+        }
+
+        @Override
+        public String buildBlockPath(BlockMetadata blockMetadata) {
+            final TopicPartition tp = blockMetadata.getTopicPartition();
+            return String.format("%s/%s/%05d-%012d", tp.topic(), dateSupplier.get(), tp.partition(),
+                    blockMetadata.getStartOffset());
+        }
+
+        @Override
+        public String buildIndexPath(TopicPartition topicPartition) {
+            return String.format("%s/last_chunk_index.%05d.txt", topicPartition.topic(), topicPartition.partition());
+        }
+    }
+
+    public static class Parser implements Layout.Parser {
+
+        private static final Pattern KEY_PATTERN = Pattern.compile(
+                // match the / or the start of the key, so we shouldn't have to worry about the prefix
+                "(/|^)"
+                        // assuming no / in topic names
+                        + "(?<topic>[^/]+?)/"
+                        + "(?<date>[^/]+?)/"
+                        + "(?<partition>\\d{5})-"
+                        + "(?<offset>\\d{12})\\.gz$"
+        );
+
+        @Override
+        public BlockMetadata parseBlockPath(String path) {
+            final Matcher matcher = KEY_PATTERN.matcher(path);
+            if (!matcher.find()) {
+                throw new IllegalArgumentException("Invalid block path: " + path);
+            }
+            final String topic = matcher.group("topic");
+            final int partition = Integer.parseInt(matcher.group("partition"));
+            final long startOffset = Long.parseLong(matcher.group("offset"));
+
+            return new BlockMetadata(new TopicPartition(topic, partition), startOffset);
+        }
+    }
+}

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3WriterTest.java
@@ -132,6 +132,11 @@ public class S3WriterTest {
 		testUpload(new GroupedByDateLayout(DATE_SUPPLIER));
 	}
 
+	@Test
+	public void testUploadGroupedByTopic() throws Exception {
+		testUpload(new GroupedByTopicLayout(DATE_SUPPLIER));
+	}
+
 	private void testUpload(Layout layout) throws Exception {
 		AmazonS3 s3Mock = mock(AmazonS3.class);
 		Layout.Builder layoutBuilder = layout.getBuilder();
@@ -177,6 +182,11 @@ public class S3WriterTest {
 		testFetchOffsetNewTopic(new GroupedByDateLayout(DATE_SUPPLIER));
 	}
 
+	@Test
+	public void testFetchOffsetNewTopicGroupedByTopic() throws Exception {
+		testFetchOffsetNewTopic(new GroupedByTopicLayout(DATE_SUPPLIER));
+	}
+
 	private void testFetchOffsetNewTopic(Layout layout) throws Exception {
 		AmazonS3 s3Mock = mock(AmazonS3.class);
 		Layout.Builder layoutBuilder = layout.getBuilder();
@@ -199,6 +209,11 @@ public class S3WriterTest {
 	@Test
 	public void testFetchOffsetExistingTopicGroupedByDate() throws Exception {
 		testFetchOffsetExistingTopic(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	@Test
+	public void testFetchOffsetExistingTopicGroupedByTopic() throws Exception {
+		testFetchOffsetExistingTopic(new GroupedByTopicLayout(DATE_SUPPLIER));
 	}
 
 	private void testFetchOffsetExistingTopic(Layout layout) throws Exception {

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -54,28 +55,36 @@ import com.spredfast.kafka.connect.s3.source.S3SourceRecord;
  * Covers S3 and reading raw byte records. Closer to an integration test.
  */
 public class S3FilesReaderTest {
-	private static final Layout.Parser LAYOUT_PARSER = new GroupedByDateLayout.Parser();
+	private static final DateSupplier DATE_SUPPLIER = new DateSupplier();
 
 	@Test
-	public void testReadingBytesFromS3() throws IOException, NoSuchFieldException {
+	public void testReadingBytesFromS3GroupedByDate() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testReadingBytesFromS3(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(dir);
+		givenSomeData(dir, layout.getBuilder());
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
-		List<String> results = whenTheRecordsAreRead(client, true, 3);
+		List<String> results = whenTheRecordsAreRead(client, layout, true, 3);
 
 		thenTheyAreFilteredAndInOrder(results);
 	}
 
 	@Test
-	public void testExcludingByMessageKey() throws IOException, NoSuchFieldException {
+	public void testExcludingByMessageKeyGroupedByDate() throws IOException, NoSuchFieldException {
+		testExcludingByMessageKey(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testExcludingByMessageKey(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(dir);
+		givenSomeData(dir, layout.getBuilder());
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
-		List<String> results = whenTheRecordsAreRead(client, Arrays.asList("1-0", "ololo"));
+		List<String> results = whenTheRecordsAreRead(client, layout, Arrays.asList("1-0", "ololo"));
 		assertEquals(Arrays.asList(
 			"key0-0=value0-0",
 			"key1-1=value1-1"
@@ -83,28 +92,36 @@ public class S3FilesReaderTest {
 	}
 
 	@Test
-	public void testReadingBytesFromS3_multiPartition() throws IOException, NoSuchFieldException {
+	public void testReadingBytesFromS3MultiPartitionGroupedByDate() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3MultiPartition(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testReadingBytesFromS3MultiPartition(Layout layout) throws IOException, NoSuchFieldException {
 		// scenario: multiple partition files at the end of a listing, page size >  # of files
 		// do we read all of them?
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenASingleDayWithManyPartitions(dir);
+		givenASingleDayWithManyPartitions(dir, layout.getBuilder());
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
-		List<String> results = whenTheRecordsAreRead(client, true, 10);
+		List<String> results = whenTheRecordsAreRead(client, layout, true, 10);
 
 		thenTheyAreFilteredAndInOrder(results);
 	}
 
 	@Test
-	public void testReadingBytesFromS3_withOffsets() throws IOException, NoSuchFieldException {
+	public void testReadingBytesFromS3WithOffsetsGroupedByDate() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithOffsets(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testReadingBytesFromS3WithOffsets(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(dir);
+		givenSomeData(dir, layout.getBuilder());
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
-		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client,
-			"prefix/2015-12-31/topic-00003-000000000001.gz", 5L, "00003"));
+		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client, layout.getParser(),
+				getKeyForFilename(layout.getBuilder(), "2015-12-31", "prefix", "topic", 3, 1, ".gz"), 5L, "00003"));
 
 		assertEquals(Arrays.asList(
 			"willbe=skipped5",
@@ -115,17 +132,20 @@ public class S3FilesReaderTest {
 		), results);
 	}
 
-
 	@Test
-	public void testReadingBytesFromS3_withOffsetsAtEndOfFile() throws IOException, NoSuchFieldException {
+	public void testReadingBytesFromS3WithOffsetsAtEndOfFileGroupedByDate() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithOffsetsAtEndOfFile(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testReadingBytesFromS3WithOffsetsAtEndOfFile(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(dir);
+		givenSomeData(dir, layout.getBuilder());
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
 		// this file will be skipped
-		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client,
-			"prefix/2015-12-30/topic-00003-000000000000.gz", 1L, "00003"));
+		List<String> results = whenTheRecordsAreRead(givenAReaderWithOffsets(client, layout.getParser(),
+				getKeyForFilename(layout.getBuilder(), "2015-12-30", "prefix", "topic", 3, 0, ".gz"), 1L, "00003"));
 
 		assertEquals(Arrays.asList(
 			"willbe=skipped1",
@@ -140,23 +160,28 @@ public class S3FilesReaderTest {
 		), results);
 	}
 
-	S3FilesReader givenAReaderWithOffsets(AmazonS3 client, String marker, long nextOffset, final String partition) {
+	private S3FilesReader givenAReaderWithOffsets(AmazonS3 client, Layout.Parser layoutParser, String marker,
+												  long nextOffset, final String partition) {
 		Map<S3Partition, S3Offset> offsets = new HashMap<>();
 		int partInt = Integer.valueOf(partition, 10);
 		offsets.put(S3Partition.from("bucket", "prefix", "topic", partInt),
 			S3Offset.from(marker, nextOffset - 1 /* an S3 offset is the last record processed, so go back 1 to consume next */));
 		return new S3FilesReader(new S3SourceConfig("bucket", "prefix", 1, null, S3FilesReader.InputFilter.GUNZIP,
-			p -> partInt == p, null), client, offsets, LAYOUT_PARSER, () -> new BytesRecordReader(true));
+			p -> partInt == p, null), client, offsets, layoutParser, () -> new BytesRecordReader(true));
 	}
 
 	@Test
-	public void testReadingBytesFromS3_withoutKeys() throws IOException, NoSuchFieldException {
+	public void testReadingBytesFromS3WithoutKeysGroupedByDate() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithoutKeys(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	private void testReadingBytesFromS3WithoutKeys(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
-		givenSomeData(dir, false);
+		givenSomeData(dir, layout.getBuilder(), false);
 
 		final AmazonS3 client = givenAMockS3Client(dir);
 
-		List<String> results = whenTheRecordsAreRead(client, false);
+		List<String> results = whenTheRecordsAreRead(client, layout, false);
 
 		theTheyAreInOrder(results);
 	}
@@ -179,19 +204,24 @@ public class S3FilesReaderTest {
 		assertEquals(expected, results);
 	}
 
-	private List<String> whenTheRecordsAreRead(AmazonS3 client, boolean fileIncludesKeys) {
-		return whenTheRecordsAreRead(client, fileIncludesKeys, 1);
+	private List<String> whenTheRecordsAreRead(AmazonS3 client, Layout layout, boolean fileIncludesKeys) {
+		return whenTheRecordsAreRead(client, layout, fileIncludesKeys, 1);
 	}
 
-	private List<String> whenTheRecordsAreRead(AmazonS3 client, List<String> messageKeyExcludeList) {
-		S3SourceConfig config = new S3SourceConfig("bucket", "prefix", 3, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, messageKeyExcludeList);
-		S3FilesReader reader = new S3FilesReader(config, client, null, LAYOUT_PARSER, () -> new BytesRecordReader(true));
+	private List<String> whenTheRecordsAreRead(AmazonS3 client, Layout layout, List<String> messageKeyExcludeList) {
+		S3SourceConfig config = new S3SourceConfig("bucket", "prefix", 3, buildStartMarker(layout.getBuilder(), "prefix", "topic", "2016-01-01"), S3FilesReader.InputFilter.GUNZIP, null, messageKeyExcludeList);
+		S3FilesReader reader = new S3FilesReader(config, client, null, layout.getParser(), () -> new BytesRecordReader(true));
 		return whenTheRecordsAreRead(reader);
 	}
 
-	private List<String> whenTheRecordsAreRead(AmazonS3 client, boolean fileIncludesKeys, int pageSize) {
-		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, "prefix/2016-01-01", S3FilesReader.InputFilter.GUNZIP, null, null), client, null, LAYOUT_PARSER, () -> new BytesRecordReader(fileIncludesKeys));
+	private List<String> whenTheRecordsAreRead(AmazonS3 client, Layout layout, boolean fileIncludesKeys, int pageSize) {
+		S3FilesReader reader = new S3FilesReader(new S3SourceConfig("bucket", "prefix", pageSize, buildStartMarker(layout.getBuilder(), "prefix", "topic", "2016-01-01"), S3FilesReader.InputFilter.GUNZIP, null, null), client, null, layout.getParser(), () -> new BytesRecordReader(fileIncludesKeys));
 		return whenTheRecordsAreRead(reader);
+	}
+
+	private String buildStartMarker(Layout.Builder layoutBuilder, String prefix, String topic, String date) {
+		return Path.of(getKeyForFilename(layoutBuilder, date, prefix, topic, 0, 0, ".gz"))
+				.getParent().toString();
 	}
 
 	private List<String> whenTheRecordsAreRead(S3FilesReader reader) {
@@ -304,66 +334,86 @@ public class S3FilesReaderTest {
 		return obj;
 	}
 
-	private void givenASingleDayWithManyPartitions(Path dir) throws IOException {
-		givenASingleDayWithManyPartitions(dir, true);
+	private void givenASingleDayWithManyPartitions(Path dir, Layout.Builder layoutBuilder) throws IOException {
+		givenASingleDayWithManyPartitions(dir, layoutBuilder, true);
 	}
 
-	private void givenASingleDayWithManyPartitions(Path dir, boolean includeKeys) throws IOException {
+	private void givenASingleDayWithManyPartitions(Path dir, Layout.Builder layoutBuilder, boolean includeKeys) throws IOException {
 		try (BlockGZIPFileWriter p0 = new BlockGZIPFileWriter(dir.toFile(), 0, 512);
 			 BlockGZIPFileWriter p1 = new BlockGZIPFileWriter(dir.toFile(), 0, 512);
 		) {
 			write(p0, "key0-0".getBytes(), "value0-0".getBytes(), includeKeys);
-			upload(p0, dir, "2016-01-01", 0);
+			upload(p0, dir, layoutBuilder, "2016-01-01", 0);
 
 			write(p1, "key1-0".getBytes(), "value1-0".getBytes(), includeKeys);
 			write(p1, "key1-1".getBytes(), "value1-1".getBytes(), includeKeys);
-			upload(p1, dir, "2016-01-01", 1);
+			upload(p1, dir, layoutBuilder, "2016-01-01", 1);
 		}
 	}
 
-	private void givenSomeData(Path dir) throws IOException {
-		givenSomeData(dir, true);
+	private void givenSomeData(Path dir, Layout.Builder layoutBuilder) throws IOException {
+		givenSomeData(dir, layoutBuilder, true);
 	}
 
-	private void givenSomeData(Path dir, boolean includeKeys) throws IOException {
+	private void givenSomeData(Path dir, Layout.Builder layoutBuilder, boolean includeKeys) throws IOException {
 		try (BlockGZIPFileWriter writer1 = new BlockGZIPFileWriter(dir.toFile(), 0, 512);
 			 BlockGZIPFileWriter writer2 = new BlockGZIPFileWriter(dir.toFile(), 1, 512);
 			 BlockGZIPFileWriter writer3 = new BlockGZIPFileWriter(dir.toFile(), 0, 512);
 			 BlockGZIPFileWriter writer4 = new BlockGZIPFileWriter(dir.toFile(), 0, 512);
 		) {
 			write(writer1, "willbe".getBytes(), "skipped0".getBytes(), includeKeys);
-			upload(writer1, dir, "2015-12-30", 3);
+			upload(writer1, dir, layoutBuilder, "2015-12-30", 3);
 
 			for (int i = 1; i < 10; i++) {
 				write(writer2, "willbe".getBytes(), ("skipped" + i).getBytes(), includeKeys);
 			}
-			upload(writer2, dir, "2015-12-31", 3);
+			upload(writer2, dir, layoutBuilder, "2015-12-31", 3);
 
 			write(writer3, "key0-0".getBytes(), "value0-0".getBytes(), includeKeys);
-			upload(writer3, dir, "2016-01-01", 0);
+			upload(writer3, dir, layoutBuilder, "2016-01-01", 0);
 
 			write(writer4, "key1-0".getBytes(), "value1-0".getBytes(), includeKeys);
 			write(writer4, "key1-1".getBytes(), "value1-1".getBytes(), includeKeys);
-			upload(writer4, dir, "2016-01-02", 1);
+			upload(writer4, dir, layoutBuilder, "2016-01-02", 1);
 		}
+	}
+
+	private String getKeyForFilename(Layout.Builder layoutBuilder, String date, String prefix, String topic,
+									 int partition, long startOffset, String extension) {
+		DATE_SUPPLIER.set(date);
+		final TopicPartition topicPartition = new TopicPartition(topic, partition);
+		final BlockMetadata blockMetadata = new BlockMetadata(topicPartition, startOffset);
+		return String.format("%s/%s%s", prefix, layoutBuilder.buildBlockPath(blockMetadata), extension);
 	}
 
 	private void write(BlockGZIPFileWriter writer, byte[] key, byte[] value, boolean includeKeys) throws IOException {
 		writer.write(new ByteLengthFormat(includeKeys).newWriter().writeBatch(Stream.of(new ProducerRecord<>("", key, value))).collect(toList()), 1);
 	}
 
-	private void upload(BlockGZIPFileWriter writer, Path dir, String date, int partition) throws IOException {
+	private void upload(BlockGZIPFileWriter writer, Path dir, Layout.Builder layoutBuilder, String date, int partition) throws IOException {
 		writer.close();
-		rename(writer.getDataFile(), dir, date, partition, writer.getStartOffset(), ".gz");
-		rename(writer.getIndexFile(), dir, date, partition, writer.getStartOffset(), ".index.json");
+		rename(writer.getDataFile(), dir, layoutBuilder, date, partition, writer.getStartOffset(), ".gz");
+		rename(writer.getIndexFile(), dir, layoutBuilder, date, partition, writer.getStartOffset(), ".index.json");
 	}
 
-	private void rename(File file, Path dir, String date, int partition, long startOffset, String extension) {
-		Layout.Builder layoutBuilder = new GroupedByDateLayout.Builder(() -> date);
-		final BlockMetadata metadata = new BlockMetadata(new TopicPartition("topic", partition), startOffset);
-		final File dest = new File(dir.toFile(), "prefix/" + layoutBuilder.buildBlockPath(metadata) + extension);
-		dest.getParentFile().mkdirs();
+	private void rename(File file, Path dir, Layout.Builder layoutBuilder, String date, int partition, long startOffset, String extension) {
+		final String key = getKeyForFilename(layoutBuilder, date, "prefix", "topic", partition, startOffset, extension);
+		final File dest = new File(dir.toFile(), key);
+		final File parent = dest.getParentFile();
+		assertTrue(parent.exists() || parent.mkdirs());
 		assertTrue(file.renameTo(dest));
 	}
 
+	private static class DateSupplier implements Supplier<String> {
+		private String date;
+
+		@Override
+		public String get() {
+			return date;
+		}
+
+		public void set(String date) {
+			this.date = date;
+		}
+	}
 }

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -298,7 +298,7 @@ public class S3FilesReaderTest {
 	S3Object getFile(String key, Path dir) throws FileNotFoundException {
 		S3Object obj = mock(S3Object.class);
 		File file = new File(dir.toString(), key);
-		when(obj.getKey()).thenReturn(file.getName());
+		when(obj.getKey()).thenReturn(key);
 		S3ObjectInputStream stream = new S3ObjectInputStream(new FileInputStream(file), null);
 		when(obj.getObjectContent()).thenReturn(stream);
 		return obj;

--- a/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
+++ b/source/src/test/java/com/spredfast/kafka/connect/s3/S3FilesReaderTest.java
@@ -62,6 +62,11 @@ public class S3FilesReaderTest {
 		testReadingBytesFromS3(new GroupedByDateLayout(DATE_SUPPLIER));
 	}
 
+	@Test
+	public void testReadingBytesFromS3GroupedByTopic() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3(new GroupedByTopicLayout(DATE_SUPPLIER));
+	}
+
 	private void testReadingBytesFromS3(Layout layout) throws IOException, NoSuchFieldException {
 		final Path dir = Files.createTempDirectory("s3FilesReaderTest");
 		givenSomeData(dir, layout.getBuilder());
@@ -76,6 +81,11 @@ public class S3FilesReaderTest {
 	@Test
 	public void testExcludingByMessageKeyGroupedByDate() throws IOException, NoSuchFieldException {
 		testExcludingByMessageKey(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	@Test
+	public void testExcludingByMessageKeyGroupedByTopic() throws IOException, NoSuchFieldException {
+		testExcludingByMessageKey(new GroupedByTopicLayout(DATE_SUPPLIER));
 	}
 
 	private void testExcludingByMessageKey(Layout layout) throws IOException, NoSuchFieldException {
@@ -96,6 +106,11 @@ public class S3FilesReaderTest {
 		testReadingBytesFromS3MultiPartition(new GroupedByDateLayout(DATE_SUPPLIER));
 	}
 
+	@Test
+	public void testReadingBytesFromS3MultiPartitionGroupedByTopic() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3MultiPartition(new GroupedByTopicLayout(DATE_SUPPLIER));
+	}
+
 	private void testReadingBytesFromS3MultiPartition(Layout layout) throws IOException, NoSuchFieldException {
 		// scenario: multiple partition files at the end of a listing, page size >  # of files
 		// do we read all of them?
@@ -112,6 +127,11 @@ public class S3FilesReaderTest {
 	@Test
 	public void testReadingBytesFromS3WithOffsetsGroupedByDate() throws IOException, NoSuchFieldException {
 		testReadingBytesFromS3WithOffsets(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	@Test
+	public void testReadingBytesFromS3WithOffsetsGroupedByTopic() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithOffsets(new GroupedByTopicLayout(DATE_SUPPLIER));
 	}
 
 	private void testReadingBytesFromS3WithOffsets(Layout layout) throws IOException, NoSuchFieldException {
@@ -135,6 +155,11 @@ public class S3FilesReaderTest {
 	@Test
 	public void testReadingBytesFromS3WithOffsetsAtEndOfFileGroupedByDate() throws IOException, NoSuchFieldException {
 		testReadingBytesFromS3WithOffsetsAtEndOfFile(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	@Test
+	public void testReadingBytesFromS3WithOffsetsAtEndOfFileGroupedByTopic() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithOffsetsAtEndOfFile(new GroupedByTopicLayout(DATE_SUPPLIER));
 	}
 
 	private void testReadingBytesFromS3WithOffsetsAtEndOfFile(Layout layout) throws IOException, NoSuchFieldException {
@@ -173,6 +198,11 @@ public class S3FilesReaderTest {
 	@Test
 	public void testReadingBytesFromS3WithoutKeysGroupedByDate() throws IOException, NoSuchFieldException {
 		testReadingBytesFromS3WithoutKeys(new GroupedByDateLayout(DATE_SUPPLIER));
+	}
+
+	@Test
+	public void testReadingBytesFromS3WithoutKeysGroupedByTopic() throws IOException, NoSuchFieldException {
+		testReadingBytesFromS3WithoutKeys(new GroupedByTopicLayout(DATE_SUPPLIER));
 	}
 
 	private void testReadingBytesFromS3WithoutKeys(Layout layout) throws IOException, NoSuchFieldException {


### PR DESCRIPTION
Review the commits one by one.

In a nutshell, the approach is the following:
1. Rework the tests where the expected object keys are hard-coded. Instead, use the layout to generate them from the block metadata.
2. Split each `@Test` method that depends on the layout into two: a public `@Test` one that instantiates a layout, and a private one that accepts the layout as a dependency.
3. Introduce a new layout and for each layout-dependent test method introduce a new one with the new layout.