### PR TITLE
CXP-2527: Remove shadow jar builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ We made the decision to hard fork when it became clear that we would be responsi
 
 ## Usage
 
-***NOTE***: You want to use the shadow jar produced by this project.
-As a gradle dependency, it is `com.spredfast.kafka.connect.s3:kafka-connect-s3:0.4.0:shadow`.
-The shadow jar ensures there are no conflicts with other libraries.
-
 Use just like any other Connector: add it to the Connect classpath and configure a task. Read the rest of this document for configuration details.
 
 ## Important Configuration
@@ -98,7 +94,7 @@ See the [wiki](https://github.com/spredfast/kafka-connect-s3/wiki) for further d
 
 ## Build and Run
 
-You should be able to build this with `./gradlew shadowJar`. Once the jar is generated in build/libs, include it in `CLASSPATH` (e.g., export `CLASSPATH=.:$CLASSPATH:/fullpath/to/kafka-connect-s3-jar` )
+You should be able to build this with `./gradlew build`. Once the jar is generated in build/libs, include it in `CLASSPATH` (e.g., export `CLASSPATH=.:$CLASSPATH:/fullpath/to/kafka-connect-s3-jar` )
 
 Run: `bin/connect-standalone.sh  example-connect-worker.properties example-connect-s3-sink.properties`(from the root directory of project, make sure you have kafka on the path, if not then give full path of kafka before `bin`)
 
@@ -187,13 +183,13 @@ Pull requests welcome! If you need ideas, check the issues for [open enhancement
 ```sh
 groupId=io.sugarcrm
 artifactId=kafka-connect-s3
-version=1.0.9-all
+version=1.0.9
 repositoryId=cxp-nexus
 mvn -s ~/.m2/settings.xml deploy:deploy-file -DgroupId=${groupId} \
     -DartifactId=${artifactId} \
     -Dversion=${version} \
     -Dpackaging=jar \
-    -Dfile=kafka-connect-s3-${version}.jar \
+    -Dfile=build/libs/kafka-connect-s3-${version}.jar \
     -DgeneratePom=true \
     -DrepositoryId=${repositoryId} \
     -Durl=https://nexus.service.sugarcrm.com/repository/cxp-public/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id "com.diffplug.spotless" version "6.15.0"
-	id "com.github.johnrengelman.shadow" version "7.1.2"
 	id 'com.palantir.git-version' version '0.15.0'
 	id 'idea'
 	id 'java-library'
@@ -48,25 +47,6 @@ allprojects {
 			formatAnnotations()
 		}
 	}
-}
-
-apply plugin: "com.github.johnrengelman.shadow"
-shadowJar {
-	dependencies {
-		// provided in the connect classpath
-		exclude(dependency('org.apache.kafka:connect-api'))
-		exclude(dependency('org.apache.kafka:kafka-clients'))
-		exclude(dependency('net.jpountz.lz4:.*:.*'))
-		exclude(dependency('org.xerial.snappy:.*:.*'))
-		exclude(dependency('org.slf4j:.*:.*'))
-	}
-
-	// for things we directly depend on, repackage so we don't conflict with other connectors
-	relocate 'com.amazonaws', 'com.spredfast.shade.amazonaws'
-	relocate 'com.fasterxml', 'com.spredfast.shade.fasterxml'
-	relocate 'org.apache.commons', 'com.spredfast.shade.apache.commons'
-	relocate 'org.apache.http', 'com.spredfast.shade.apache.http'
-	relocate 'org.joda', 'com.spredfast.shade.joda'
 }
 
 dependencies {

--- a/sink/build.gradle
+++ b/sink/build.gradle
@@ -7,29 +7,6 @@ test {
 	}
 }
 
-apply plugin: "com.github.johnrengelman.shadow"
-
-shadowJar {
-	dependencies {
-		// provided in the connect classpath
-		exclude(dependency('org.apache.kafka:connect-api'))
-		exclude(dependency('org.apache.kafka:kafka-clients'))
-		exclude(dependency('net.jpountz.lz4:.*:.*'))
-		exclude(dependency('org.xerial.snappy:.*:.*'))
-		exclude(dependency('org.slf4j:.*:.*'))
-	}
-
-	// for things we directly depend on, repackage so we don't conflict with other connectors
-	relocate 'com.amazonaws', 'com.spredfast.shade.amazonaws'
-	relocate 'com.fasterxml', 'com.spredfast.shade.fasterxml'
-	relocate 'org.apache.commons', 'com.spredfast.shade.apache.commons'
-	relocate 'org.apache.http', 'com.spredfast.shade.apache.http'
-	relocate 'org.joda', 'com.spredfast.shade.joda'
-}
-
-tasks.build.dependsOn tasks.shadowJar
-tasks.test.dependsOn tasks.shadowJar
-
 dependencies {
     implementation project(':common')
 

--- a/system_test/README.md
+++ b/system_test/README.md
@@ -67,6 +67,6 @@ The same should work with regular ssh for a non-docker machine VM.
 From the repo root dir, run:
 
 ```
-./gradlew shadowJar
+./gradlew build
 python system_test/run.py
 ```


### PR DESCRIPTION
In the current state, the connector fails with the following error:
```
java.lang.NoClassDefFoundError: com/spredfast/kafka/connect/s3/Configure
	at com.spredfast.kafka.connect.s3.sink.S3SinkTask.start(S3SinkTask.java:72)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:312)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:187)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:244)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: com.spredfast.kafka.connect.s3.Configure
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:103)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 9 more
```

It looks like, besides the jar of the module, the test needs to download the jars of all its dependencies and mount them to the Kafka Connect container.