### PR TITLE
CXP-2523: Stream Kafka Connect container logs to stdout during sink connector tests

### DIFF
--- a/sink/build.gradle
+++ b/sink/build.gradle
@@ -1,5 +1,12 @@
 description = "Kafka Connect Sink that writes to S3"
 
+test {
+	testLogging {
+		outputs.upToDateWhen {false}
+		showStandardStreams = true
+	}
+}
+
 apply plugin: "com.github.johnrengelman.shadow"
 
 shadowJar {
@@ -33,4 +40,6 @@ dependencies {
 	testImplementation("net.mguenther.kafka:kafka-junit")
 	testImplementation("org.testcontainers:kafka")
 	testImplementation("org.testcontainers:localstack")
+	testImplementation("ch.qos.logback:logback-core:1.4.5")
+	testImplementation("ch.qos.logback:logback-classic:1.4.5")
 }

--- a/sink/src/test/java/com/spredfast/kafka/connect/s3/S3SinkConnectorIT.java
+++ b/sink/src/test/java/com/spredfast/kafka/connect/s3/S3SinkConnectorIT.java
@@ -43,6 +43,7 @@ import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 public class S3SinkConnectorIT {
 
@@ -64,6 +65,9 @@ public class S3SinkConnectorIT {
   public static DebeziumContainer kafkaConnectContainer =
       DebeziumContainer.latestStable()
           .withFileSystemBind("build/libs", "/kafka/connect/s3-sink-connector")
+          .withCopyToContainer(
+              MountableFile.forClasspathResource("log4j.properties"),
+              "/kafka/config/log4j.properties")
           .withNetwork(network)
           .withKafka(kafkaContainer)
           .withLogConsumer(new Slf4jLogConsumer(LOGGER))

--- a/sink/src/test/resources/log4j.properties
+++ b/sink/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+kafka.logs.dir=logs
+
+log4j.rootLogger=WARN, stdout, appender
+
+# Disable excessive reflection warnings - KAFKA-5229
+log4j.logger.org.reflections=ERROR
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.threshold=DEBUG
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+
+
+log4j.appender.appender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.appender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.appender.File=${kafka.logs.dir}/connect-service.log
+log4j.appender.appender.layout=org.apache.log4j.PatternLayout
+log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+
+# s3 sink connector
+log4j.logger.com.spredfast.kafka.connect.s3.sink.S3SinkTask=DEBUG

--- a/sink/src/test/resources/logback-test.xml
+++ b/sink/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="warn">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="com.spredfast.kafka.connect.s3.S3SinkConnectorIT" level="DEBUG"/>
+	<logger name="org.testcontainers" level="WARN"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+	<logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
This makes the S3SinkTask log output available to stdout For example, here is a snippet of the log output:
```
    19:05:13.452 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,452 DEBUG  ||  s3-sink performing a periodic flush on system_test-0   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.452 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,452 DEBUG  ||  s3-sink preparing offsets for partition: system_test-0, totalCompressedSize: 0   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.453 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,453 DEBUG  ||  s3-sink performing a periodic flush on system_test-1   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.454 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,454 DEBUG  ||  s3-sink preparing offsets for partition: system_test-1, totalCompressedSize: 0   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.454 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,454 DEBUG  ||  s3-sink performing a periodic flush on system_test-2   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.455 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,454 DEBUG  ||  s3-sink preparing offsets for partition: system_test-2, totalCompressedSize: 0   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.455 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,455 DEBUG  ||  s3-sink flushing offsets: {system_test-0=OffsetAndMetadata{offset=236, leaderEpoch=null, metadata=''}, system_test-1=OffsetAndMetadata{offset=32, leaderEpoch=null, metadata=''}, system_test-2=OffsetAndMetadata{offset=32, leaderEpoch=null, metadata=''}}   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
    19:05:13.759 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,758 WARN   ||  Ignoring stop request for unowned connector s3-sink   [org.apache.kafka.connect.runtime.Worker]
    19:05:13.759 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,758 WARN   ||  Ignoring await stop request for non-present connector s3-sink   [org.apache.kafka.connect.runtime.Worker]
    19:05:13.767 [docker-java-stream--1417591419] INFO  com.spredfast.kafka.connect.s3.S3SinkConnectorIT - STDOUT: 2023-03-14 19:05:13,767 DEBUG  ||  s3-sink performing preCommit with offsets: {system_test-0=OffsetAndMetadata{offset=236, leaderEpoch=null, metadata=''}, system_test-1=OffsetAndMetadata{offset=32, leaderEpoch=null, metadata=''}, system_test-2=OffsetAndMetadata{offset=32, leaderEpoch=null, metadata=''}}   [com.spredfast.kafka.connect.s3.sink.S3SinkTask]
```