### PR TITLE
CXP-3032: Race condition during `local.buffer.dir` creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ allprojects {
 	apply plugin: 'maven-publish'
 
 	group = 'com.spredfast.kafka.connect.s3'
-	version = '1.2.0'
+	version = '1.2.1'
 
 	apply plugin: 'java-library'
 	sourceCompatibility = 11

--- a/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
+++ b/sink/src/main/java/com/spredfast/kafka/connect/s3/sink/S3SinkTask.java
@@ -233,7 +233,11 @@ public class S3SinkTask extends SinkTask {
               .orElseThrow(() -> new ConnectException("No local buffer directory configured"));
 
       File directory = new File(localBufferDirectory);
-      if (!directory.exists() && !directory.mkdirs()) {
+      int attempts = 3;
+      while (attempts > 0 && !directory.exists() && !directory.mkdirs()) {
+        attempts--;
+      }
+      if (!directory.exists()) {
         throw new ConnectException("Could not create directory " + localBufferDirectory);
       }
 


### PR DESCRIPTION
When multiple tasks are starte on the same worker all of them are trying to check if the directory exists and create if not. Sometimes some of the tasks fail because the directory gets created after the existence check and before the creation attempt by other tasks.

The fix is to do a few attempts of checking and creating the directory.